### PR TITLE
Deactivate configs and delete configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,9 @@ arch = ["amd64", "arm64"]
 # Lower values are sorted before other confible parts. Default: "1000" (optional)
 priority = 1000
 path = "path/to/target"
-# Enable truncate for erasing target file beforehand. Default: "false" (optional).
+# Enable truncate for erasing target file before writing/updating. 
+# If the '-clean-id' or '-clean-all' flag is used, the target file will be completely removed.
+# Default: "false" (optional).
 truncate = false
 # When any directories need to be created to store the config at the given path,
 # the given permissions will be set for those directories. Default: 0o700 (optional).

--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ I want to say {{ .Var.say }}
 ```
 
 
-## Config Specification
+## Config Reference
 
 ```toml
 [settings]
+# Disable processing of the given confible file.
+deactivated = false
 # the ID allows to execute different configs to the same path
 id = "some unique identifier"
 # Filter the operating system. Only when the machines OS matches, the file gets processed.

--- a/internal/confible/confible.go
+++ b/internal/confible/confible.go
@@ -10,9 +10,10 @@ type File struct {
 }
 
 type Settings struct {
-	ID    string   `toml:"id"`
-	OSs   []string `toml:"os"`
-	Archs []string `toml:"arch"`
+	Deactivated bool     `toml:"deactivated"`
+	ID          string   `toml:"id"`
+	OSs         []string `toml:"os"`
+	Archs       []string `toml:"arch"`
 }
 
 type Config struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,11 @@ func ModifyTargetFiles(confibleFile confible.File, useCached bool, cacheFilepath
 				return fmt.Errorf("failed appending new content: %w", err)
 			}
 		case ModeCleanID, ModeCleanAll:
+			if cfg.Truncate {
+				log.Printf("[%v] deleted config %q as truncate was enabled\n", confibleFile.Settings.ID, cfg.Path)
+				return os.Remove(cfg.Path)
+			}
+
 			var existingConfigs []confibleConfig
 			newContent, existingConfigs, err = fileContent(targetFile)
 			if err != nil {
@@ -180,7 +185,7 @@ func ModifyTargetFiles(confibleFile confible.File, useCached bool, cacheFilepath
 			return fmt.Errorf("failed setting file permisions %q on %q: %v", permFile, cfg.Path, err)
 		}
 
-		log.Printf("[%v] wrote config to %q\n", confibleFile.Settings.ID, cfg.Path)
+		log.Printf("[%v] wrote/updated config %q\n", confibleFile.Settings.ID, cfg.Path)
 	}
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -88,6 +88,10 @@ func processConfibleFiles(configPaths []string, execCmds, applyCfgs, cachedCmds,
 		}
 
 		// check if we can skip this file
+		if cfg.Settings.Deactivated {
+			log.Printf("[%v] skipping as deactivated\n", cfg.Settings.ID)
+			continue
+		}
 		if len(cfg.Settings.OSs) != 0 && !slices.Contains(cfg.Settings.OSs, runtime.GOOS) {
 			log.Printf("[%v] skipping as operating system %q is not matching settings filter %q\n", cfg.Settings.ID, runtime.GOOS, cfg.Settings.OSs)
 			continue


### PR DESCRIPTION
- Add an option to disable confible files.
- Delete config files when using the -clean flags and the truncate setting is enabled.